### PR TITLE
Handle missing Supabase env in dashboards

### DIFF
--- a/app/tutor/page.tsx
+++ b/app/tutor/page.tsx
@@ -11,7 +11,7 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Users, BookOpen, Trophy, ArrowLeft, Plus, Trash2, Target, Copy } from "lucide-react"
 import Link from "next/link"
-import { supabase } from "@/lib/supabase/client"
+import { supabase, isSupabaseConfigured } from "@/lib/supabase/client"
 import Image from "next/image"
 
 interface Student {
@@ -36,6 +36,16 @@ interface Tutor {
 const materias = ["Programación I", "Contabilidad", "Comunicación"]
 
 export default function TutorDashboard() {
+  if (!isSupabaseConfigured) {
+    return (
+      <div className="p-4">
+        <p className="text-center text-sm text-muted-foreground">
+          Supabase no está configurado. El panel de tutor está deshabilitado.
+        </p>
+      </div>
+    )
+  }
+
   const [selectedTutor, setSelectedTutor] = useState("")
   const [tutorPassword, setTutorPassword] = useState("")
   const [passwordError, setPasswordError] = useState("")
@@ -60,6 +70,7 @@ export default function TutorDashboard() {
   })
 
   const loadTutors = async () => {
+    if (!isSupabaseConfigured) return
     try {
       const { data: tutorsData, error: tutorsError } = await supabase.from("tutors").select("name")
 
@@ -94,6 +105,7 @@ export default function TutorDashboard() {
       return
     }
 
+    if (!isSupabaseConfigured) return
     try {
       setIsLoading(true)
 
@@ -134,10 +146,12 @@ export default function TutorDashboard() {
   }
 
   useEffect(() => {
+    if (!isSupabaseConfigured) return
     loadTutors()
   }, [])
 
   const loadStudents = async (materia: string) => {
+    if (!isSupabaseConfigured) return
     try {
       setIsLoading(true)
 
@@ -225,6 +239,7 @@ export default function TutorDashboard() {
 
   const clearSemesterData = async () => {
     if (!selectedMateria) return
+    if (!isSupabaseConfigured) return
 
     const confirmed = window.confirm(
       `¿Estás seguro de que quieres eliminar TODOS los datos del bimestre para ${selectedMateria}? Esta acción no se puede deshacer.`,
@@ -300,6 +315,7 @@ export default function TutorDashboard() {
   }
 
   useEffect(() => {
+    if (!isSupabaseConfigured) return
     if (selectedMateria) {
       loadStudents(selectedMateria)
     }
@@ -318,6 +334,7 @@ export default function TutorDashboard() {
   }
 
   const loadAdminData = async () => {
+    if (!isSupabaseConfigured) return
     await loadTutors()
     await loadSubjects()
     setAdminTutors(tutores)
@@ -326,6 +343,7 @@ export default function TutorDashboard() {
   const deleteTutor = async (tutorName: string) => {
     if (!confirm(`¿Estás seguro de eliminar al tutor ${tutorName}?`)) return
 
+    if (!isSupabaseConfigured) return
     try {
       setIsLoading(true)
 
@@ -345,6 +363,7 @@ export default function TutorDashboard() {
   const createNewMateria = async () => {
     if (!newMateriaName.trim()) return
 
+    if (!isSupabaseConfigured) return
     try {
       setIsLoading(true)
 
@@ -388,6 +407,7 @@ export default function TutorDashboard() {
   const deleteMateria = async (materia: string) => {
     if (!confirm(`¿Estás seguro de eliminar la materia ${materia}?`)) return
 
+    if (!isSupabaseConfigured) return
     try {
       setIsLoading(true)
 
@@ -410,6 +430,7 @@ export default function TutorDashboard() {
   }
 
   const loadSubjects = async () => {
+    if (!isSupabaseConfigured) return
     try {
       const { data: subjectsData, error } = await supabase.from("subjects").select("name").order("name")
 
@@ -426,6 +447,7 @@ export default function TutorDashboard() {
   }
 
   const assignTutorToSubject = async (tutorName: string, subjectName: string) => {
+    if (!isSupabaseConfigured) return
     try {
       setIsLoading(true)
 
@@ -455,6 +477,7 @@ export default function TutorDashboard() {
   const removeTutorFromSubject = async (tutorName: string, subjectName: string) => {
     if (!confirm(`¿Estás seguro de quitar a ${tutorName} de ${subjectName}?`)) return
 
+    if (!isSupabaseConfigured) return
     try {
       setIsLoading(true)
 

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -7,15 +7,9 @@ export const isSupabaseConfigured =
   typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === "string" &&
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY.length > 0
 
-export const supabase = createBrowserClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "",
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "",
-)
-
-export const validateSupabaseConnection = () => {
-  if (!isSupabaseConfigured) {
-    throw new Error(
-      "Supabase environment variables are not configured. Please check NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in your project settings.",
+export const supabase = isSupabaseConfigured
+  ? createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     )
-  }
-}
+  : ({} as any)


### PR DESCRIPTION
## Summary
- Avoid runtime errors in dashboards when Supabase env vars are absent
- Only instantiate Supabase client when credentials exist
- Gracefully disable tutor dashboard without Supabase configuration

## Testing
- `pnpm build` *(fails: Failed to fetch fonts DM Sans and Space Grotesk)*

------
https://chatgpt.com/codex/tasks/task_e_68c645f31388832ab5457425e7261913